### PR TITLE
Add the option to skip full seasons torrents

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ apt install python3 python3-configargparse python3-libtorrent python3-requests p
 ## Usage
 
 ```
-usage: rssdl.py [-h] [-c CONFIG_FILE] -t TORRENTS_DIR -f FEED_URL [-d]
+usage: rssdl.py [-h] [-c CONFIG_FILE] -t TORRENTS_DIR -f FEED_URL [-s] [-d]
 
 Args that start with '--' (eg. -t) can also be set in a config file
 (<path_to_rssdl>/rssdl.conf or specified via -c). Config file syntax allows:
@@ -61,6 +61,7 @@ optional arguments:
                         Path to write Torrents files.
   -f FEED_URL, --feed-url FEED_URL
                         URL to your personal showRSS feed.
+  -s, --skip-seasons    Do not download full seasons.
   -d, --debug           Run in debug mode.
 ```
 

--- a/rssdl.conf.example
+++ b/rssdl.conf.example
@@ -1,2 +1,3 @@
 feed-url = 
 torrents-dir = 
+skip-seasons = false

--- a/rssdl.py
+++ b/rssdl.py
@@ -173,7 +173,7 @@ def fetch_torrents(entries, skip_seasons=False):
 
 
 def setup_logging():
-    """Set-up logging."""
+    """Set up logging."""
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
Recently showRSS decided to push full seasons torrent when a season ends. There's no way to disable this feature in showRSS custom feed so RSSdl can do it for you.

# Changes

* Add `-s` command line parameter to skip full season torrents